### PR TITLE
Use atomic setex call instead of set and expire

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ mongooseRedisCache = function(mongoose, options, callback) {
             return callback(err);
           }
           str = JSON.stringify(docs);
-          client.set(key, str);
-          client.expire(key, expires);
+          client.setex(key, expires, str);
           return callback(null, docs);
         });
       } else {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -65,8 +65,7 @@ mongooseRedisCache = (mongoose, options, callback) ->
         mongoose.Query::_execFind.call self, (err, docs) ->
           if err then return callback err
           str = JSON.stringify docs
-          client.set key, str
-          client.expire key, expires
+          client.setex key, expires, str
           callback null, docs
       else
         # Key is found, yay! Return the baby! 


### PR DESCRIPTION
Redis has [setex](http://redis.io/commands/setex) command which is the better alternative to `set` + `expire`.
