### PR TITLE
Allow users to disable caching when calling find

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ mongooseRedisCache = function(mongoose, options, callback) {
     fields = _.clone(this._fields);
     schemaOptions = model.schema.options;
     expires = schemaOptions.expires || 60;
-    if (!schemaOptions.redisCache && !options.nocache && options.lean) {
+    if (!(schemaOptions.redisCache && !options.nocache && options.lean)) {
       return mongoose.Query.prototype._execFind.apply(self, arguments);
     }
     delete options.nocache;

--- a/index.js
+++ b/index.js
@@ -32,9 +32,10 @@ mongooseRedisCache = function(mongoose, options, callback) {
     fields = _.clone(this._fields);
     schemaOptions = model.schema.options;
     expires = schemaOptions.expires || 60;
-    if (!schemaOptions.redisCache && options.lean) {
+    if (!schemaOptions.redisCache && !options.nocache && options.lean) {
       return mongoose.Query.prototype._execFind.apply(self, arguments);
     }
+    delete options.nocache;
     key = JSON.stringify(query) + JSON.stringify(options) + JSON.stringify(fields);
     cb = function(err, result) {
       var docs;

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,10 @@ Then,
             Do whatever here! 
         });
 
+    Use nocache option to disable caching for the given query:
+
+        query = Example.find({}).setOptions({nocache: true})
+
 Check out the test example for more information. 
 
 ## Test results: 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -48,10 +48,12 @@ mongooseRedisCache = (mongoose, options, callback) ->
     schemaOptions = model.schema.options
     expires = schemaOptions.expires || 60
 
-    # We only use redis cache of user specified to use cache on the schema, 
-    # and it will only execute if the call is a lean call. 
-    if not schemaOptions.redisCache and options.lean
+    # We only use redis cache of user specified to use cache on the schema,
+    # and it will only execute if the call is a lean call.
+    if not schemaOptions.redisCache and not options.nocache and options.lean
       return mongoose.Query::_execFind.apply self, arguments
+
+    delete options.nocache
 
     key = JSON.stringify(query) + JSON.stringify(options) + JSON.stringify(fields)
     

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -50,7 +50,7 @@ mongooseRedisCache = (mongoose, options, callback) ->
 
     # We only use redis cache of user specified to use cache on the schema,
     # and it will only execute if the call is a lean call.
-    if not schemaOptions.redisCache and not options.nocache and options.lean
+    unless schemaOptions.redisCache and not options.nocache and options.lean
       return mongoose.Query::_execFind.apply self, arguments
 
     delete options.nocache


### PR DESCRIPTION
Sometimes is't desirable to  disable caching for some queries.

I suggest using query options to do so:

```
query = Example.find({}).setOptions({nocache: true})
```
