### PR TITLE
Overcaching on population

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,11 +38,18 @@ mongooseRedisCache = function(mongoose, options, callback) {
     delete options.nocache;
     key = JSON.stringify(query) + JSON.stringify(options) + JSON.stringify(fields);
     cb = function(err, result) {
-      var docs;
+      var docs, k, path;
       if (err) {
         return callback(err);
       }
       if (!result) {
+        for (k in populate) {
+          path = populate[k];
+          path.options || (path.options = {});
+          _.defaults(path.options, {
+            nocache: true
+          });
+        }
         return mongoose.Query.prototype._execFind.call(self, function(err, docs) {
           var str;
           if (err) {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -64,6 +64,10 @@ mongooseRedisCache = (mongoose, options, callback) ->
         # If the key is not found in Redis, executes Mongoose original 
         # execFind() function and then cache the results in Redis
 
+        for k, path of populate
+          path.options ||= {}
+          _.defaults path.options, nocache: true
+
         mongoose.Query::_execFind.call self, (err, docs) ->
           if err then return callback err
           str = JSON.stringify docs


### PR DESCRIPTION
When you querying MongoDB in mongoose with population it makes several queries calling `execFind` multiple times.

Current implementation caches every cal to `execFind`. So, each populated fields appear in cache twice.

Mongoose always lists `_id`s explicitly in its population query, so it seems improbable to me to hit such a cache.

So, I added `nocache` default option to all population queries to prevent ovarcaching.
